### PR TITLE
ExceptionRenderer improvements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,9 @@ notifications:
 nuget:
   disable_publish_on_pr: true
 
+init:
+  - git config --global core.autocrlf false
+
 before_build:
   - appveyor-retry nuget restore -DisableParallelProcessing
 build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.2.{build}
+version: 2.3.{build}
 image: Visual Studio 2017
 
 configuration:

--- a/toofz.Tests/ExceptionRendererTests.cs
+++ b/toofz.Tests/ExceptionRendererTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.CodeDom.Compiler;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using toofz.TestsShared;
 
 namespace toofz.Tests
 {
@@ -9,6 +10,25 @@ namespace toofz.Tests
         [TestClass]
         public class RenderStackTrace
         {
+            [TestMethod]
+            public void StackTraceIsNull_DoesNotThrowNullReferenceException()
+            {
+                // Arrange
+                string stackTrace = null;
+                using (var sw = new StringWriter())
+                using (var indentedTextWriter = new IndentedTextWriter(sw))
+                {
+                    // Act
+                    var ex = Record.Exception(() =>
+                    {
+                        ExceptionRenderer.RenderStackTrace(stackTrace, indentedTextWriter);
+                    });
+
+                    // Assert
+                    Assert.IsNull(ex);
+                }
+            }
+
             [TestMethod]
             [Ignore("Paths will not match on different machines.")]
             public void StackTraceFromThrownException_RendersStackTraceCorrectly()

--- a/toofz.Tests/ExceptionRendererTests.cs
+++ b/toofz.Tests/ExceptionRendererTests.cs
@@ -30,7 +30,6 @@ namespace toofz.Tests
             }
 
             [TestMethod]
-            [Ignore("Paths will not match on different machines.")]
             public void StackTraceFromThrownException_RendersStackTraceCorrectly()
             {
                 // Arrange
@@ -39,20 +38,19 @@ namespace toofz.Tests
                 using (var indentedTextWriter = new IndentedTextWriter(sw))
                 {
                     // Act
-                    ExceptionRenderer.RenderStackTrace(ex.StackTrace, indentedTextWriter);
+                    ExceptionRenderer.RenderStackTrace(ex.StackTrace, indentedTextWriter, true);
                     var output = sw.ToString();
 
                     // Assert
                     var expected = @"
 StackTrace:
-       at toofz.Tests.ExceptionHelper.ThrowException() in S:\Projects\toofz\toofz.Tests\ExceptionHelper.cs:line 10
-       at toofz.TestsShared.Record.Exception(Action testCode) in C:\projects\toofz-testsshared\toofz.TestsShared\Record.cs:line 33";
+    toofz.Tests.ExceptionHelper.ThrowException()
+    toofz.TestsShared.Record.Exception(Action testCode)";
                     Assert.AreEqual(expected, output);
                 }
             }
 
             [TestMethod]
-            [Ignore("Not sure why this one fails on AppVeyor.")]
             public void StackTraceFromUnthrownException_RendersStackTraceCorrectly()
             {
                 // Arrange
@@ -63,14 +61,14 @@ StackTrace:
                 using (var indentedTextWriter = new IndentedTextWriter(sw))
                 {
                     // Act
-                    ExceptionRenderer.RenderStackTrace(ex.StackTrace, indentedTextWriter);
+                    ExceptionRenderer.RenderStackTrace(ex.StackTrace, indentedTextWriter, true);
                     var output = sw.ToString();
 
                     // Assert
                     var expected = @"
 StackTrace:
-       at toofz.Tests.ExceptionHelper.ThrowException() in S:\Projects\toofz\toofz.Tests\ExceptionHelper.cs:line 10
-       at toofz.TestsShared.Record.Exception(Action testCode) in C:\projects\toofz-testsshared\toofz.TestsShared\Record.cs:line 33";
+    toofz.Tests.ExceptionHelper.ThrowException()
+    toofz.TestsShared.Record.Exception(Action testCode)";
                     Assert.AreEqual(expected, output);
                 }
             }

--- a/toofz.Tests/ExceptionRendererTests.cs
+++ b/toofz.Tests/ExceptionRendererTests.cs
@@ -46,7 +46,7 @@ namespace toofz.Tests
 StackTrace:
     toofz.Tests.ExceptionHelper.ThrowException()
     toofz.TestsShared.Record.Exception(Action testCode)";
-                    Assert.AreEqual(expected, output);
+                    AssertHelper.NormalizedAreEqual(expected, output);
                 }
             }
 
@@ -69,7 +69,7 @@ StackTrace:
 StackTrace:
     toofz.Tests.ExceptionHelper.ThrowException()
     toofz.TestsShared.Record.Exception(Action testCode)";
-                    Assert.AreEqual(expected, output);
+                    AssertHelper.NormalizedAreEqual(expected, output);
                 }
             }
         }

--- a/toofz.Tests/packages.config
+++ b/toofz.Tests/packages.config
@@ -9,5 +9,5 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="RichardSzalay.MockHttp" version="1.5.0" targetFramework="net45" />
   <package id="System.Net.Http" version="4.3.2" targetFramework="net45" />
-  <package id="toofz.TestsShared" version="1.0.0" targetFramework="net45" />
+  <package id="toofz.TestsShared" version="1.3.0" targetFramework="net45" />
 </packages>

--- a/toofz.Tests/toofz.Tests.csproj
+++ b/toofz.Tests/toofz.Tests.csproj
@@ -68,8 +68,8 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="toofz.TestsShared, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\toofz.TestsShared.1.0.0\lib\net45\toofz.TestsShared.dll</HintPath>
+    <Reference Include="toofz.TestsShared, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\toofz.TestsShared.1.3.0\lib\net45\toofz.TestsShared.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/toofz.sln
+++ b/toofz.sln
@@ -7,6 +7,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "toofz", "toofz\toofz.csproj
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "toofz.Tests", "toofz.Tests\toofz.Tests.csproj", "{784CFD35-B344-4C96-B340-5ADAFEF97CF5}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution files", "Solution files", "{5B785F76-A880-4C92-A703-AC282490D777}"
+	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
+		NuGet.Config = NuGet.Config
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/toofz/ExceptionRenderer.cs
+++ b/toofz/ExceptionRenderer.cs
@@ -16,6 +16,8 @@ namespace toofz
 
         internal static void RenderStackTrace(string stackTrace, IndentedTextWriter indentedWriter)
         {
+            stackTrace = stackTrace ?? "";
+
             var stackFrames = stackTrace.Split(new string[] { "\r\n", "\n" }, StringSplitOptions.None);
 
             if (stackFrames.Length == 0)

--- a/toofz/ExceptionRenderer.cs
+++ b/toofz/ExceptionRenderer.cs
@@ -14,7 +14,10 @@ namespace toofz
     {
         static readonly ILog Log = LogManager.GetLogger(typeof(ExceptionRenderer));
 
-        internal static void RenderStackTrace(string stackTrace, IndentedTextWriter indentedWriter)
+        internal static void RenderStackTrace(
+            string stackTrace,
+            IndentedTextWriter indentedWriter,
+            bool suppressFileInfo = false)
         {
             stackTrace = stackTrace ?? "";
 
@@ -30,11 +33,20 @@ namespace toofz
             {
                 if (stackFrame.StartsWith("   at "))
                 {
+                    var _stackFrame = stackFrame.Remove(0, 6);
                     // Stack frames from System.Runtime.CompilerServices are generally internals for handling async methods. 
                     // They produce a lot of noise in logs so we filter them out when rendering stack traces.
-                    if (!stackFrame.StartsWith("   at System.Runtime.CompilerServices"))
+                    if (!_stackFrame.StartsWith("System.Runtime.CompilerServices"))
                     {
-                        indentedWriter.WriteLineStart(stackFrame);
+                        if (suppressFileInfo)
+                        {
+                            var inIndex = _stackFrame.IndexOf(" in ");
+                            if (inIndex > -1)
+                            {
+                                _stackFrame = _stackFrame.Substring(0, inIndex);
+                            }
+                        }
+                        indentedWriter.WriteLineStart(_stackFrame);
                     }
                 }
                 else if (stackFrame.StartsWith("---"))

--- a/toofz/Properties/AssemblyInfo.cs
+++ b/toofz/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("toofz")]
 [assembly: AssemblyProduct("toofz")]
-[assembly: AssemblyVersion("2.2.0.*")]
+[assembly: AssemblyVersion("2.3.0.*")]
 [assembly: AssemblyCompany("toofz")]
 [assembly: AssemblyCopyright("Copyright © Leonard Thieu 2015")]
 [assembly: ComVisible(false)]

--- a/toofz/toofz.csproj
+++ b/toofz/toofz.csproj
@@ -64,6 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="toofz.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/toofz/toofz.nuspec
+++ b/toofz/toofz.nuspec
@@ -2,7 +2,7 @@
 <package>
     <metadata>
         <id>toofz</id>
-        <version>2.2.0</version>
+        <version>2.3.0</version>
         <title>toofz</title>
         <authors>Leonard Thieu</authors>
         <owners>Leonard Thieu</owners>
@@ -10,7 +10,6 @@
         <projectUrl>https://github.com/leonard-thieu/toofz</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Utility library.</description>
-        <releaseNotes>Migrated utility types from toofz-necrodancer.</releaseNotes>
         <copyright>Copyright 2017</copyright>
         <tags>toofz utility</tags>
     </metadata>


### PR DESCRIPTION
* `ExceptionRenderer` no longer throws a `NullReferenceException` when `stackTrace` is null.
* Remove leading "   at " in stack frames. This should improve readability of output.