### PR TITLE
Secrets is no longer public

### DIFF
--- a/toofz.Tests/EncryptedSecretTests.cs
+++ b/toofz.Tests/EncryptedSecretTests.cs
@@ -16,11 +16,12 @@ namespace toofz.Tests
             {
                 // Arrange
                 string secret = null;
+                int iterations = 1000;
 
                 // Act -> Assert
                 Assert.ThrowsException<ArgumentException>(() =>
                 {
-                    new EncryptedSecret(secret);
+                    new EncryptedSecret(secret, iterations);
                 });
             }
 
@@ -29,11 +30,12 @@ namespace toofz.Tests
             {
                 // Arrange
                 string secret = "";
+                int iterations = 1000;
 
                 // Act -> Assert
                 Assert.ThrowsException<ArgumentException>(() =>
                 {
-                    new EncryptedSecret(secret);
+                    new EncryptedSecret(secret, iterations);
                 });
             }
 
@@ -42,9 +44,10 @@ namespace toofz.Tests
             {
                 // Arrange
                 string secret = "mySecret";
+                int iterations = 1000;
 
                 // Act
-                var encryptedSecret = new EncryptedSecret(secret);
+                var encryptedSecret = new EncryptedSecret(secret, iterations);
 
                 // Assert
                 Assert.IsInstanceOfType(encryptedSecret, typeof(EncryptedSecret));
@@ -59,7 +62,8 @@ namespace toofz.Tests
             {
                 // Arrange
                 string secret = "mySecret";
-                var encryptedSecret = new EncryptedSecret(secret);
+                int iterations = 1000;
+                var encryptedSecret = new EncryptedSecret(secret, iterations);
 
                 // Act
                 var decryptedSecret = encryptedSecret.Decrypt();
@@ -76,7 +80,7 @@ namespace toofz.Tests
             public void ReturnsNull()
             {
                 // Arrange
-                var encryptedSecret = new EncryptedSecret("mySecret");
+                var encryptedSecret = new EncryptedSecret("mySecret", 1000);
                 var xml = (IXmlSerializable)encryptedSecret;
 
                 // Act
@@ -102,7 +106,7 @@ namespace toofz.Tests
                 var property = SettingsUtil.CreateProperty<EncryptedSecret>("myProp");
                 property.SerializeAs = SettingsSerializeAs.Xml;
                 var value = new SettingsPropertyValue(property);
-                var encryptedSecret = new EncryptedSecret("mySecret");
+                var encryptedSecret = new EncryptedSecret("mySecret", 1000);
                 value.PropertyValue = encryptedSecret;
                 values.Add(value);
 

--- a/toofz.Tests/SecretsTests.cs
+++ b/toofz.Tests/SecretsTests.cs
@@ -14,11 +14,12 @@ namespace toofz.Tests
             {
                 // Arrange
                 string secret = null;
+                int iterations = 1000;
 
                 // Act -> Assert
                 Assert.ThrowsException<ArgumentException>(() =>
                 {
-                    Secrets.Encrypt(secret);
+                    Secrets.Encrypt(secret, iterations);
                 });
             }
 
@@ -27,11 +28,26 @@ namespace toofz.Tests
             {
                 // Arrange
                 string secret = "";
+                int iterations = 1000;
 
                 // Act -> Assert
                 Assert.ThrowsException<ArgumentException>(() =>
                 {
-                    Secrets.Encrypt(secret);
+                    Secrets.Encrypt(secret, iterations);
+                });
+            }
+
+            [TestMethod]
+            public void IterationsIsNegative_ThrowsArgumentOutOfRangeException()
+            {
+                // Arrange
+                string secret = "mySecret";
+                int iterations = -1;
+
+                // Act -> Assert
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
+                {
+                    Secrets.Encrypt(secret, iterations);
                 });
             }
 
@@ -40,9 +56,10 @@ namespace toofz.Tests
             {
                 // Arrange
                 string secret = "mySecret";
+                int iterations = 1000;
 
                 // Act
-                var (encrypted, salt) = Secrets.Encrypt(secret);
+                var (encrypted, salt) = Secrets.Encrypt(secret, iterations);
 
                 // Assert
                 Assert.IsTrue(encrypted.Any());
@@ -53,9 +70,10 @@ namespace toofz.Tests
             {
                 // Arrange
                 string secret = "mySecret";
+                int iterations = 1000;
 
                 // Act
-                var (encrypted, salt) = Secrets.Encrypt(secret);
+                var (encrypted, salt) = Secrets.Encrypt(secret, iterations);
 
                 // Assert
                 Assert.IsTrue(salt.Any());
@@ -71,11 +89,12 @@ namespace toofz.Tests
                 // Arrange
                 byte[] encrypted = null;
                 byte[] salt = new byte[8];
+                int iterations = 1000;
 
                 // Act -> Assert
                 Assert.ThrowsException<ArgumentNullException>(() =>
                 {
-                    Secrets.Decrypt(encrypted, salt);
+                    Secrets.Decrypt(encrypted, salt, iterations);
                 });
             }
 
@@ -85,11 +104,12 @@ namespace toofz.Tests
                 // Arrange
                 byte[] encrypted = new byte[8];
                 byte[] salt = null;
+                int iterations = 1000;
 
                 // Act -> Assert
                 Assert.ThrowsException<ArgumentNullException>(() =>
                 {
-                    Secrets.Decrypt(encrypted, salt);
+                    Secrets.Decrypt(encrypted, salt, iterations);
                 });
             }
 
@@ -99,11 +119,27 @@ namespace toofz.Tests
                 // Arrange
                 byte[] encrypted = new byte[8];
                 byte[] salt = new byte[0];
+                int iterations = 1000;
 
                 // Act -> Assert
                 Assert.ThrowsException<ArgumentException>(() =>
                 {
-                    Secrets.Decrypt(encrypted, salt);
+                    Secrets.Decrypt(encrypted, salt, iterations);
+                });
+            }
+
+            [TestMethod]
+            public void IterationsIsNegative_ThrowsArgumentOutOfRangeException()
+            {
+                // Arrange
+                byte[] encrypted = new byte[8];
+                byte[] salt = new byte[8];
+                int iterations = -1;
+
+                // Act -> Assert
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
+                {
+                    Secrets.Decrypt(encrypted, salt, iterations);
                 });
             }
 
@@ -112,10 +148,11 @@ namespace toofz.Tests
             {
                 // Arrange
                 var secret = "mySecret";
-                var (encrypted, salt) = Secrets.Encrypt(secret);
+                int iterations = 1000;
+                var (encrypted, salt) = Secrets.Encrypt(secret, iterations);
 
                 // Act
-                var decrypted = Secrets.Decrypt(encrypted, salt);
+                var decrypted = Secrets.Decrypt(encrypted, salt, iterations);
 
                 // Assert
                 Assert.AreEqual(secret, decrypted);

--- a/toofz/EncryptedSecret.cs
+++ b/toofz/EncryptedSecret.cs
@@ -9,6 +9,7 @@ namespace toofz
     {
         const string SecretName = "Secret";
         const string SaltName = "Salt";
+        const string IterationsName = "Iterations";
 
         // Required for XML serialization
         EncryptedSecret() { }
@@ -20,13 +21,15 @@ namespace toofz
         /// <exception cref="System.ArgumentException">
         /// <paramref name="secret"/> cannot be null or empty.
         /// </exception>
-        public EncryptedSecret(string secret)
+        public EncryptedSecret(string secret, int iterations)
         {
-            (this.secret, salt) = Secrets.Encrypt(secret);
+            (this.secret, salt) = Secrets.Encrypt(secret, iterations);
+            this.iterations = iterations;
         }
 
         byte[] secret;
         byte[] salt;
+        int iterations;
 
         /// <summary>
         /// Decrypts the encrypted secret.
@@ -34,7 +37,7 @@ namespace toofz
         /// <returns>
         /// The decrypted secret.
         /// </returns>
-        public string Decrypt() => Secrets.Decrypt(secret, salt);
+        public string Decrypt() => Secrets.Decrypt(secret, salt, iterations);
 
         #region IXmlSerializable Members
 
@@ -51,6 +54,7 @@ namespace toofz
             reader.ReadStartElement(nameof(EncryptedSecret));
             secret = Convert.FromBase64String(reader.ReadElementContentAsString(SecretName, ""));
             salt = Convert.FromBase64String(reader.ReadElementContentAsString(SaltName, ""));
+            iterations = reader.ReadElementContentAsInt(IterationsName, "");
             reader.ReadEndElement();
         }
 
@@ -68,6 +72,10 @@ namespace toofz
 
             writer.WriteStartElement(SaltName);
             writer.WriteBase64(salt, 0, salt.Length);
+            writer.WriteEndElement();
+
+            writer.WriteStartElement(IterationsName);
+            writer.WriteValue(iterations);
             writer.WriteEndElement();
         }
 


### PR DESCRIPTION
`Secrets` was public so consumers could tune the number of iterations based on their needs but global state is difficult to manage and is a bad practice. Consumers are now required to specify the number of iterations when encrypting a secret. The number of iterations is now stored with the encrypted secret.